### PR TITLE
Added new books, blogs, videos and tools for M2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Here's some helpful resources for learning Magento 2:
 * [Magento 2 Development Cookbook](http://www.amazon.co.uk/gp/product/1785882198/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=1785882198&linkCode=as2&tag=shop1404-21) by Bart Delvaux
 * [Mastering Magento 2](http://www.amazon.co.uk/gp/product/1785882368/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=1785882368&linkCode=as2&tag=shop1404-21) by Bret Williams & Jonathan Bownds (Pre-Order for July 2016)
 
+### Tools
+* [Commerce Bug 3](http://store.pulsestorm.net/products/commerce-bug-3) by Alan Storm
+* [Jetbrains Magento 2 Plugin](https://plugins.jetbrains.com/plugin/8024) by Dmytro Kvashnin
+* [Magicento 2 (beta)](http://magicento.com/) by Enrique Piatti
+
 If we've missed one, please submit a pull request to add it!
 
 ## Opening Issues

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Here's some helpful resources for learning Magento 2:
 * [Magento 2 Development Cookbook](http://www.amazon.co.uk/gp/product/1785882198/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=1785882198&linkCode=as2&tag=shop1404-21) by Bart Delvaux
 * [Mastering Magento 2](http://www.amazon.co.uk/gp/product/1785882368/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=1785882368&linkCode=as2&tag=shop1404-21) by Bret Williams & Jonathan Bownds (Pre-Order for July 2016)
 * [Magento 2 Primer: Getting stuff done with Magento 2 - Kindle Edition](http://www.amazon.co.uk/gp/product/B019PCMJ7A/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=B019PCMJ7A&linkCode=as2&tag=shop1404-21) by Alan Kent 
+* [Magento 2: Theme Web Page Assets: Getting Stuff Done with Magento 2 - Kindle Edition](http://www.amazon.co.uk/gp/product/B01COQPQG0/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=B01COQPQG0&linkCode=as2&tag=shop1404-21) by Alan Kent 
+* [Magento 2 Cookbook](http://www.amazon.co.uk/gp/product/1785887068/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=1785887068&linkCode=as2&tag=shop1404-21) by Ray Bogman
 
 ### Tools
 * [Commerce Bug 3](http://store.pulsestorm.net/products/commerce-bug-3) by Alan Storm

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Here's some helpful resources for learning Magento 2:
 * [Magento 2 Developers Guide](http://www.amazon.co.uk/gp/product/1785886584/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=1785886584&linkCode=as2&tag=shop1404-21) by Branko Ajzele
 * [Magento 2 Development Cookbook](http://www.amazon.co.uk/gp/product/1785882198/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=1785882198&linkCode=as2&tag=shop1404-21) by Bart Delvaux
 * [Mastering Magento 2](http://www.amazon.co.uk/gp/product/1785882368/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=1785882368&linkCode=as2&tag=shop1404-21) by Bret Williams & Jonathan Bownds (Pre-Order for July 2016)
+* [Magento 2 Primer: Getting stuff done with Magento 2 - Kindle Edition](http://www.amazon.co.uk/gp/product/B019PCMJ7A/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=B019PCMJ7A&linkCode=as2&tag=shop1404-21) by Alan Kent 
 
 ### Tools
 * [Commerce Bug 3](http://store.pulsestorm.net/products/commerce-bug-3) by Alan Storm

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Here's some helpful resources for learning Magento 2:
 * Max Yekaterynenko (Head of Magento 2 Development): https://maxyek.wordpress.com/ 
 * Ash Smith blog: https://www.ashsmith.io/
 * IBNAB blog: http://www.ibnab.com/en/blog/magento-2
+* Vinai Kopp blog: http://vinaikopp.com/blog/list/
 
 ### Books
 * [Magento 2 Developers Guide](http://www.amazon.co.uk/gp/product/1785886584/ref=as_li_tl?ie=UTF8&camp=1634&creative=6738&creativeASIN=1785886584&linkCode=as2&tag=shop1404-21) by Branko Ajzele

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Here's some helpful resources for learning Magento 2:
 * [Jetbrains Magento 2 Plugin](https://plugins.jetbrains.com/plugin/8024) by Dmytro Kvashnin
 * [Magicento 2 (beta)](http://magicento.com/) by Enrique Piatti
 
+## Videos 
+* [Mage 2 Kata](https://www.youtube.com/channel/UCRFDWo7jTlrpEsJxzc7WyPw) by Vinai Kopp
+
 If we've missed one, please submit a pull request to add it!
 
 ## Opening Issues


### PR DESCRIPTION
The following changes have been made:
1. Added a link to the blog for Vinai Kopp
2. Added a link for the new Alan Kent book on M2 development
3. Added in links for development tools that can aid with development
4. Added in a videos section and included the Mage 2 Kata series 
